### PR TITLE
FIX: Fix sum of total_retrans.

### DIFF
--- a/mrr.c
+++ b/mrr.c
@@ -162,6 +162,7 @@ check_thread(void *arg)
   /* Do nother with locking */
   while (1) {
     usleep(100);
+    uint32_t temp_total_retrans = 0;
     int i;
     for (i = 0; i < checker_so_num; i++) {
       int so = checker_so[i];
@@ -182,8 +183,9 @@ check_thread(void *arg)
         max_retransmits = info.tcpi_retransmits;
       if (max_backoff == 0 || max_backoff < info.tcpi_backoff)
         max_backoff = info.tcpi_backoff;
-      total_retrans += info.tcpi_total_retrans;
+      temp_total_retrans += info.tcpi_total_retrans;
     }
+    total_retrans = temp_total_retrans;
   }
   return NULL;
 }


### PR DESCRIPTION
https://github.com/jam2in/arcus-works/issues/356
https://github.com/naver/arcus-misc/pull/2

total_retrans 수치가 비정상적으로 집계되는 현상을 수정했습니다.

# AS-IS
1. 100us 마다 각 TCP Connection에 대한 total_retrans 값의 합계를 구함
2. **1의 값을 전역 변수에 더함**
3. 1초마다 2의 전역 변수 값을 출력한 뒤 0으로 초기화

## 예시
- 10개의 TCP Connection에 각각 total_retrans 값이 1이라면
- 각 TCP Connection에 대한 total_retrans 값의 합계는 10
- 10을 100us 마다 전역 변수에 더함
- 1초마다 전역 변수를 출력하므로, (1 second / 100us) = 1만번 집계되어 (1만 * 10) = 10만의 값이 출력됨

# TO-BE
1. 100us 마다 각 TCP Connection에 대한 total_retrans 값의 합계를 구함
2. **1의 값을 전역 변수에 대입**
3. 1초마다 2의 전역 변수 값을 출력

## 예시

- 10개의 TCP Connection에 각각 total_retrans 값이 1이라면
- 각 TCP Connection에 대한 total_retrans 값의 합계는 10
- 10을 100us 마다 전역 변수에 대입
- 1초마다 전역 변수 출력하지만, 더하는 것이 아니라 대입하는 것이므로 10의 값이 출력됨