### PR TITLE
INTERNAL: Add support for multi platform Docker image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+VERSION ?= develop
 
 all: mrr
 
@@ -8,4 +9,7 @@ clean:
 	rm -f *.o mrr
 
 docker:
-	docker build --tag mrr:latest .
+	- docker buildx create --name project-v3-builder
+	docker buildx use project-v3-builder
+	- docker buildx build --push --platform=linux/arm64,linux/amd64 --tag jam2in/mrr:${VERSION} --progress tty .
+	- docker buildx rm project-v3-builder


### PR DESCRIPTION
https://github.com/naver/arcus-memcached/commit/cebea54338a31dda4419b2897a687412306b73f8

위 커밋을 참고하여 amd64, arm64에서 구동 가능한 도커 이미지를 생성하도록 변경했습니다.