### PR TITLE
FEATURE: Add support for MacOS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*
+!AUTHORS
+!ChangeLog
+!Dockerfile
+!LICENSE
+!Makefile
+!mrr.c
+!README.md
+!.gitignore


### PR DESCRIPTION
기존에는 Linux 환경에서만 사용 가능했는데, MacOS에서도 사용 가능하도록 했습니다.
MacOS 10.11+ 버전에서 사용 가능한 구조체인 tcp_connection_info를 사용합니다.
MacOS 10.11 버전은 2015년 6월 8일에 릴리즈되었습니다.

Linux의 tcp_info에는 있는데 MacOS의 tcp_connection_info에는 없는 지표는 MacOS에서 구동할 때 수집하지 않습니다.
- tcpi_backoff
- tcpi_retransmits

그 외에는 서로 동일한 의미를 갖는 지표를 수집하도록 했습니다.